### PR TITLE
添加飞机悬停在地图上

### DIFF
--- a/my-app/src/page/point.jsx
+++ b/my-app/src/page/point.jsx
@@ -7,12 +7,13 @@ Cesium.Ion.defaultAccessToken='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI3
 
 async function loadModel(viewer , positionProperty ,start , stop) {
     // Load the glTF model from Cesium ion.
-    const dataPoint = { longitude: -122.38985, latitude: 37.61864, height: -10.3 };
+    const dataPoint = { longitude: -74.015, latitude: 40.72, height: 750 };//
     const airplaneUri = await Cesium.IonResource.fromAssetId('185430');
     const airplaneEntity = viewer.entities.add({
         description: `First data point at (${dataPoint.longitude}, ${dataPoint.latitude})`,
         position: Cesium.Cartesian3.fromDegrees(dataPoint.longitude, dataPoint.latitude, dataPoint.height),
         model: { uri: airplaneUri },
+		
         // point: { pixelSize: 10, color: Cesium.Color.RED }
     });
     viewer.flyTo(airplaneEntity);
@@ -27,6 +28,7 @@ function App() {
             const viewer = new Cesium.Viewer(cesiumContainer2.current, {
                 terrainProvider: Cesium.createWorldTerrain()
             });
+			viewer.scene.primitives.add(Cesium.createOsmBuildings());
             const osmBuildings = viewer.scene.primitives.add(Cesium.createOsmBuildings());
             viewer.camera.flyTo({
                 destination: Cesium.Cartesian3.fromDegrees(-122.384, 37.62, 4000)


### PR DESCRIPTION
1.fork项目到自己的git上
2.根据cesium官网，悬停飞机模型在曼哈顿上空
3.根据提供的坐标位置找到曼哈顿第一贸易中心，让飞机在曼哈顿第一贸易中心环绕一周。飞行高度为400，无碰撞建筑物，飞机的头指向建筑中心。
  问题1：环绕的解决方案：创建了8个飞行轨迹让飞机根据8个点连线通过改变轨迹样条插值变成圆环
  问题2：飞机头指向建筑中心，目前只能起始的时候指向，但是在轨迹改变了方向之后，机头的位置没有改变。解决思路：每次改变轨迹方向可以重新渲染飞机模型。

